### PR TITLE
codespell added

### DIFF
--- a/nextjsUIapp/.codespellrc
+++ b/nextjsUIapp/.codespellrc
@@ -1,0 +1,6 @@
+[codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = .git*,.codespellrc,Data
+check-hidden = true
+ignore-regex = ^\s*"image/\S+": ".*
+# ignore-words-list =


### PR DESCRIPTION
Added codespell. Taken from [https://github.com/sensein/assertion-evidence-paper/blob/main/.codespellrc](https://github.com/sensein/assertion-evidence-paper/blob/main/.codespellrc).