### PR TITLE
Fix public pages that required a signed-in session

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -42,10 +42,32 @@ function jwtExpMs(token?: string | null): number {
   }
 }
 
+// How long NextAuth keeps its OWN session cookie alive. This must not outlive the
+// backend's web refresh token (USERMANAGEMENT_WEB_REFRESH_TTL_MIN, default 10080 =
+// 7 days). NextAuth's default is 30 days, which left a ~23-day window where the
+// cookie still reported `authenticated` — navbar, avatar, everything — while the
+// backend credential behind it was gone, so every service call failed with
+// "requires a signed-in session". Set NEXTAUTH_SESSION_MAX_AGE_SEC if the backend's
+// TTL is customised; keep it equal to or shorter than that value.
+const SESSION_MAX_AGE_SEC = (() => {
+  const n = Number(process.env.NEXTAUTH_SESSION_MAX_AGE_SEC);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : 7 * 24 * 60 * 60;
+})();
+
+// Outcome of a refresh attempt. The distinction matters: "rejected" means the
+// refresh token itself is dead (expired, revoked, account deactivated) and the user
+// must sign in again, while "unavailable" means we could not ask (network blip,
+// 502 during a redeploy, service restarting) and says nothing about the token. The
+// old code returned null for both and cleared the credentials either way, so a
+// few-second backend hiccup permanently signed everyone out.
+type RefreshResult =
+  | { status: "ok"; token: string }
+  | { status: "rejected" }
+  | { status: "unavailable" };
+
 // Exchange a web refresh token for a fresh usermanagement access token so the
-// session doesn't drop when the short access token expires. Returns the new
-// access token, or null on failure (caller then forces re-login).
-async function refreshBackendToken(refreshToken: string): Promise<string | null> {
+// session doesn't drop when the short access token expires.
+async function refreshBackendToken(refreshToken: string): Promise<RefreshResult> {
   try {
     const res = await fetch(`${userManagementBaseUrl()}/api/auth/exchange`, {
       method: "POST",
@@ -53,17 +75,24 @@ async function refreshBackendToken(refreshToken: string): Promise<string | null>
       body: JSON.stringify({ audience: "usermanagement" }),
       cache: "no-store",
     });
-    if (!res.ok) return null;
-    const data = await res.json();
-    return (data.access_token as string) ?? null;
+    if (res.ok) {
+      const data = await res.json();
+      const access = (data.access_token as string) ?? null;
+      return access ? { status: "ok", token: access } : { status: "rejected" };
+    }
+    // Only the auth codes are a verdict on the token.
+    return res.status === 401 || res.status === 403
+      ? { status: "rejected" }
+      : { status: "unavailable" };
   } catch {
-    return null;
+    return { status: "unavailable" };
   }
 }
 
 export const authOptions: NextAuthOptions = {
   secret: process.env.NEXTAUTH_SECRET || generateFallbackSecret(),
-  session: { strategy: "jwt" },
+  session: { strategy: "jwt", maxAge: SESSION_MAX_AGE_SEC },
+  jwt: { maxAge: SESSION_MAX_AGE_SEC },
   providers: [
     CredentialsProvider({
       id: "backend-jwt",
@@ -121,6 +150,7 @@ export const authOptions: NextAuthOptions = {
         token.scopes = u.scopes ?? [];
         token.authSource = u.authSource ?? "password";
         (token as any).orcid_id = u.orcid_id ?? null;
+        (token as any).error = undefined; // a fresh login clears any previous expiry
         return token;
       }
 
@@ -129,19 +159,40 @@ export const authOptions: NextAuthOptions = {
       const exp = (token as any).backendTokenExp as number | undefined;
       const refresh = (token as any).backendRefreshToken as string | undefined;
       const SKEW_MS = 60_000; // renew ~1 min before expiry
-      if (refresh && (token as any).backendToken && (!exp || Date.now() > exp - SKEW_MS)) {
-        const fresh = await refreshBackendToken(refresh);
-        if (fresh) {
-          (token as any).backendToken = fresh;
-          (token as any).backendTokenExp = jwtExpMs(fresh);
-        } else {
-          // Refresh failed (expired/revoked/inactive) — drop the backend token so
-          // the app treats the user as signed out and re-prompts login.
-          (token as any).backendToken = undefined;
-          (token as any).backendTokenExp = 0;
-          (token as any).backendRefreshToken = undefined;
-        }
+
+      if (!(token as any).backendToken) return token; // already expired; see below
+      if (exp && Date.now() < exp - SKEW_MS) return token; // still valid
+
+      if (!refresh) {
+        // Signed in without a refresh token — an older backend build, or a login
+        // that took the CLI path (oauth.py mints `refresh` for web logins only).
+        // Nothing can renew this, so once the access token lapses the session is
+        // over. Mark it rather than leaving a dead token in place for every caller
+        // to 401 on individually.
+        (token as any).backendToken = undefined;
+        (token as any).backendTokenExp = 0;
+        (token as any).error = "SessionExpired";
+        return token;
       }
+
+      const res = await refreshBackendToken(refresh);
+      if (res.status === "ok") {
+        (token as any).backendToken = res.token;
+        (token as any).backendTokenExp = jwtExpMs(res.token);
+        (token as any).error = undefined;
+      } else if (res.status === "rejected") {
+        // The refresh token is expired, revoked, or the account was deactivated.
+        // Drop the credentials AND flag it, so the UI signs the user out centrally
+        // instead of each feature surfacing its own "please sign in" error.
+        (token as any).backendToken = undefined;
+        (token as any).backendTokenExp = 0;
+        (token as any).backendRefreshToken = undefined;
+        (token as any).error = "SessionExpired";
+      }
+      // "unavailable": keep the credentials we have and try again on the next call.
+      // The access token may already be past `exp` — a real 401 from the backend is
+      // the correct outcome then, and it is recoverable; discarding the refresh
+      // token would not be.
       return token;
     },
     async session({ session, token }) {
@@ -152,6 +203,10 @@ export const authOptions: NextAuthOptions = {
       s.roles = token.roles ?? [];
       s.scopes = token.scopes ?? [];
       s.authSource = token.authSource ?? "password";
+      // Surfaced to the browser so SessionExpiryWatcher can sign the user out once,
+      // centrally. Without it, a session whose backend credential is gone still
+      // reads as `authenticated` and every feature fails on its own.
+      s.error = (token as any).error ?? undefined;
       if (s.user) {
         s.user.orcid_id = (token as any).orcid_id ?? null;
       }

--- a/src/app/components/auth/SessionExpiryWatcher.tsx
+++ b/src/app/components/auth/SessionExpiryWatcher.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+/**
+ * Turns an expired backend credential into one visible, app-wide sign-out.
+ *
+ * The NextAuth session cookie and the backend JWT it carries have independent
+ * lifetimes. When the backend side lapses (refresh token expired or revoked, account
+ * deactivated), lib/auth.ts drops the token and sets `session.error =
+ * "SessionExpired"` — but the cookie itself is still valid, so `useSession()` keeps
+ * reporting `authenticated`. Without this component the user stays "signed in" while
+ * every service call fails on its own terms: SynthScholar logs `[Auth] Failed to get
+ * auth token for ml`, the knowledge-base pages fail their query-service exchange, the
+ * dashboard fails /api/users/me. Same cause, one message per feature, none of them
+ * actionable.
+ *
+ * Mounted once inside SessionProvider (src/app/layout.tsx) so it covers every route.
+ */
+
+import { useEffect, useState } from "react";
+import { useSession, signOut } from "next-auth/react";
+
+export default function SessionExpiryWatcher() {
+  const { data: session, status } = useSession();
+  const [expired, setExpired] = useState(false);
+
+  useEffect(() => {
+    if (status !== "authenticated") return;
+    if ((session as any)?.error !== "SessionExpired") return;
+    setExpired(true);
+    // redirect: false — the user keeps their place, and the navbar reverts to the
+    // sign-in buttons on its own. Clearing the cookie also stops the loop: the next
+    // render has no session, so this effect does not fire again.
+    void signOut({ redirect: false });
+  }, [session, status]);
+
+  if (!expired) return null;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="fixed bottom-4 left-1/2 z-50 -translate-x-1/2 flex items-center gap-3
+                 rounded-md border border-amber-300 bg-amber-50 px-4 py-3 shadow-lg"
+    >
+      <span className="text-sm text-amber-900">
+        Your session expired. Sign in again to continue.
+      </span>
+      <button
+        onClick={() => setExpired(false)}
+        className="text-sm font-medium text-amber-900 underline hover:no-underline"
+      >
+        Dismiss
+      </button>
+    </div>
+  );
+}

--- a/src/app/knowledge-base/synth-scholar/[id]/page.tsx
+++ b/src/app/knowledge-base/synth-scholar/[id]/page.tsx
@@ -25,24 +25,29 @@ import {
   Activity,
   FileText,
 } from "lucide-react";
+// Public (unauthenticated) reads — see usePublicReview*. The authenticated hooks
+// cannot serve this page: they need a session to exchange for an ml_service token,
+// and their endpoints 404 for anyone who is not the review's author, so even a
+// published review was invisible to its readers.
 import {
-  useReview,
-  useReviewLog,
-  useExportReview,
+  usePublicReview,
+  usePublicReviewLog,
+  useExportPublicReview,
 } from "@/src/hooks/useSynthScholar";
 import { MarkdownContent } from "@/src/app/components/synth-scholar/MarkdownContent";
 import { ProvenanceTimelinePublic } from "@/src/app/components/synth-scholar/ProvenanceTimelinePublic";
 import type {
   ArticleSummary,
   GRADEAssessment,
+  ReviewDetail,
 } from "@/src/types/synthScholar";
 
 export default function PublicReviewDetailPage() {
   const params = useParams();
   const reviewId = decodeURIComponent((params?.id as string) || "");
-  const { data, isLoading, error } = useReview(reviewId || undefined);
-  const log = useReviewLog(reviewId || undefined);
-  const exportMut = useExportReview();
+  const { data, isLoading, error } = usePublicReview(reviewId || undefined);
+  const log = usePublicReviewLog(reviewId || undefined);
+  const exportMut = useExportPublicReview();
 
   const isPublicCompleted =
     data?.is_public === true && data?.status === "completed";
@@ -387,7 +392,7 @@ function Section({ title, children }: { title: string; children: React.ReactNode
 function PRISMAFlowCard({
   flow,
 }: {
-  flow: NonNullable<ReturnType<typeof useReview>["data"]>["flow"];
+  flow: ReviewDetail["flow"];
 }) {
   if (!flow) return null;
   const cells: Array<[string, number | string]> = [

--- a/src/app/knowledge-base/synth-scholar/page.tsx
+++ b/src/app/knowledge-base/synth-scholar/page.tsx
@@ -8,18 +8,26 @@
  * other knowledge-base list pages (e.g. /knowledge-base/ner) so the surface
  * stays consistent. Each row links to a public detail view that exposes the
  * synthesis text plus a small set of downloads — no editing UI.
+ *
+ * Reads ml_service's unauthenticated /public/reviews. It used to call the
+ * authenticated listing and filter client-side, which could not work either way:
+ * an anonymous visitor has no session to exchange for a token, and a signed-in one
+ * got their OWN reviews, since that endpoint is owner-scoped. The published set now
+ * comes from the server already filtered.
  */
 
 import React from "react";
 import Link from "next/link";
 import { Search, Loader2, AlertCircle } from "lucide-react";
-import { useReviews } from "@/src/hooks/useSynthScholar";
+import { usePublicReviews } from "@/src/hooks/useSynthScholar";
 import type { ReviewSummary } from "@/src/types/synthScholar";
 
 export default function PublicReviewsListPage() {
-  const { data, isLoading, error } = useReviews();
+  const { data, isLoading, error } = usePublicReviews();
   const [searchQuery, setSearchQuery] = React.useState("");
 
+  // The endpoint already returns only published, completed reviews. Kept as a
+  // belt-and-braces guard so a backend change can never surface a draft here.
   const publicReviews = React.useMemo(
     () =>
       (data ?? []).filter(

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Inter } from "next/font/google";
 import "./globals.css";
 import { getServerSession } from "next-auth";
 import SessionProvider from "./components/auth/SessionProvider";
+import SessionExpiryWatcher from "./components/auth/SessionExpiryWatcher";
 import Footer from "./Footer";
 import dynamic from "next/dynamic"; // Required for Client Component import
 // Dynamically import the BrainKB Assistant client component
@@ -63,6 +64,9 @@ export default async function RootLayout({ children }: { children: React.ReactNo
       </noscript>
 
       <SessionProvider session={session}>
+          {/* One place that reacts to an expired backend credential, instead of
+              every feature reporting its own "please sign in" failure. */}
+          <SessionExpiryWatcher/>
           <QueryProvider>
               <header>
                   <ConditionalNavbar/>

--- a/src/hooks/useSynthScholar.ts
+++ b/src/hooks/useSynthScholar.ts
@@ -27,6 +27,10 @@ import {
   getReviewLog,
   cancelReview,
   retryReview,
+  listPublicReviews,
+  getPublicReview,
+  getPublicReviewLog,
+  exportPublicReview,
 } from "@/src/services/api/synthScholar";
 import type {
   RunReviewRequest,
@@ -175,35 +179,81 @@ export function useSetCacheSharing() {
   });
 }
 
+// Shared by the authenticated and public export hooks so the downloaded filename
+// is identical either way.
+function _downloadExport(blob: Blob, format: ExportFormat, model?: string) {
+  const EXT: Record<string, string> = {
+    markdown: "md", bibtex: "bib", ttl: "ttl", jsonld: "jsonld", json: "json",
+    rubric_markdown: "md", rubric_json: "json",
+    charting_markdown: "md", charting_json: "json",
+    appraisal_markdown: "md", appraisal_json: "json",
+    narrative_summary_markdown: "md", narrative_summary_json: "json",
+  };
+  const STEM: Record<string, string> = {
+    rubric_markdown: "prisma_rubrics", rubric_json: "prisma_rubrics",
+    charting_markdown: "prisma_charting", charting_json: "prisma_charting",
+    appraisal_markdown: "prisma_appraisal", appraisal_json: "prisma_appraisal",
+    narrative_summary_markdown: "prisma_narrative_summary",
+    narrative_summary_json: "prisma_narrative_summary",
+  };
+  const ext = EXT[format] ?? "json";
+  const stem = STEM[format] ?? "prisma_review";
+  const modelSlug = model ? "_" + model.replace(/[^a-zA-Z0-9_-]+/g, "-").replace(/^-+|-+$/g, "") : "";
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `${stem}${modelSlug}.${ext}`;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
 export function useExportReview() {
   return useMutation({
     mutationFn: ({ reviewId, format, model }: { reviewId: string; format: ExportFormat; model?: string }) =>
       exportReview(reviewId, format, model),
-    onSuccess: (blob, { format, model }) => {
-      const EXT: Record<string, string> = {
-        markdown: "md", bibtex: "bib", ttl: "ttl", jsonld: "jsonld", json: "json",
-        rubric_markdown: "md", rubric_json: "json",
-        charting_markdown: "md", charting_json: "json",
-        appraisal_markdown: "md", appraisal_json: "json",
-        narrative_summary_markdown: "md", narrative_summary_json: "json",
-      };
-      const STEM: Record<string, string> = {
-        rubric_markdown: "prisma_rubrics", rubric_json: "prisma_rubrics",
-        charting_markdown: "prisma_charting", charting_json: "prisma_charting",
-        appraisal_markdown: "prisma_appraisal", appraisal_json: "prisma_appraisal",
-        narrative_summary_markdown: "prisma_narrative_summary",
-        narrative_summary_json: "prisma_narrative_summary",
-      };
-      const ext = EXT[format] ?? "json";
-      const stem = STEM[format] ?? "prisma_review";
-      const modelSlug = model ? "_" + model.replace(/[^a-zA-Z0-9_-]+/g, "-").replace(/^-+|-+$/g, "") : "";
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = `${stem}${modelSlug}.${ext}`;
-      a.click();
-      URL.revokeObjectURL(url);
-    },
+    onSuccess: (blob, { format, model }) => _downloadExport(blob, format, model),
+  });
+}
+
+// ── Public reads (no sign-in) ────────────────────────────────────────
+// Used by /knowledge-base/synth-scholar. Kept separate from the hooks above
+// rather than made conditional: the authenticated ones require a session to
+// exchange for an ml_service token, so calling them from a public page fails
+// before any request goes out. Separate query keys too — a signed-in author
+// browsing the public listing must not see their own owner-scoped listing
+// served from cache in its place.
+
+export function usePublicReviews() {
+  return useQuery({
+    queryKey: ["synth-scholar", "public", "reviews"],
+    queryFn: listPublicReviews,
+    staleTime: 60_000, // published reviews are complete; they do not move
+  });
+}
+
+export function usePublicReview(reviewId: string | undefined) {
+  return useQuery({
+    queryKey: ["synth-scholar", "public", "review", reviewId],
+    queryFn: () => getPublicReview(reviewId!),
+    enabled: !!reviewId,
+    staleTime: 60_000,
+  });
+}
+
+export function usePublicReviewLog(reviewId: string | undefined) {
+  return useQuery({
+    queryKey: ["synth-scholar", "public", "review-log", reviewId],
+    queryFn: () => getPublicReviewLog(reviewId!),
+    enabled: !!reviewId,
+    staleTime: 60_000,
+  });
+}
+
+export function useExportPublicReview() {
+  return useMutation({
+    mutationFn: ({ reviewId, format, model }: { reviewId: string; format: ExportFormat; model?: string }) =>
+      exportPublicReview(reviewId, format, model),
+    onSuccess: (blob, { format, model }) => _downloadExport(blob, format, model),
   });
 }
 

--- a/src/services/api/synthScholar.ts
+++ b/src/services/api/synthScholar.ts
@@ -198,6 +198,65 @@ export async function getReviewLog(reviewId: string): Promise<{
   return fetchJSON(`/reviews/${reviewId}/log`);
 }
 
+// ── Public (unauthenticated) reads ────────────────────────────────────
+// For /knowledge-base/synth-scholar, which anyone can open. These MUST NOT touch
+// getMlServiceToken(): an anonymous visitor has no session to exchange, so asking
+// for a token throws before the request is made — that is the "ML service requires
+// a signed-in session" error the public pages were failing with.
+//
+// They hit ml_service's /public/* routes, which serve only reviews their author
+// marked Public and return 404 for anything else. Server-side filtering matters:
+// the authenticated /reviews listing is owner-scoped, so using it here showed a
+// visitor their own reviews rather than the published ones.
+
+async function fetchPublicJSON<T>(path: string): Promise<T> {
+  const res = await fetch(`${API_BASE}/public${path}`, { headers: { Accept: "application/json" } });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(formatApiDetail((body as any)?.detail, res.status));
+  }
+  return res.json();
+}
+
+export async function listPublicReviews(): Promise<ReviewSummary[]> {
+  return fetchPublicJSON("/reviews");
+}
+
+export async function getPublicReview(reviewId: string): Promise<ReviewDetail> {
+  return fetchPublicJSON(`/reviews/${reviewId}`);
+}
+
+export async function getPublicReviewLog(reviewId: string): Promise<{
+  review_id: string;
+  status: string;
+  step_count: number;
+  log: string[];
+  log_events?: LogEvent[];
+}> {
+  return fetchPublicJSON(`/reviews/${reviewId}/log`);
+}
+
+export async function exportPublicReview(
+  reviewId: string,
+  format: ExportFormat,
+  model?: string,
+): Promise<Blob> {
+  const params = new URLSearchParams({ format });
+  if (model) params.set("model", model);
+  const res = await fetch(`${API_BASE}/public/reviews/${reviewId}/export?${params}`);
+  if (!res.ok) {
+    let detail = "";
+    try {
+      const body = await res.json();
+      detail = formatApiDetail((body as any)?.detail, res.status);
+    } catch {
+      try { detail = await res.text(); } catch { /* ignore */ }
+    }
+    throw new Error(detail || `Export failed (HTTP ${res.status})`);
+  }
+  return res.blob();
+}
+
 // ── Export ────────────────────────────────────────────────────────────
 
 export async function exportReview(

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -30,16 +30,22 @@ declare module "next-auth" {
     roles?: string[];
     scopes?: string[];
     authSource?: string;
+    // "SessionExpired" once the backend credential behind this session is gone and
+    // cannot be renewed. SessionExpiryWatcher turns it into a single sign-out.
+    error?: "SessionExpired";
   }
 }
 
 declare module "next-auth/jwt" {
   interface JWT {
     backendToken?: string;
+    backendRefreshToken?: string | null;
+    backendTokenExp?: number;
     profileId?: number | null;
     userId?: number | null;
     roles?: string[];
     scopes?: string[];
     authSource?: string;
+    error?: "SessionExpired";
   }
 }


### PR DESCRIPTION
/knowledge-base/synth-scholar and its detail page are reachable without signing in, but read SynthScholar through the authenticated client. That cannot work for an anonymous visitor: getAuthTokenForService('ml') needs a session to exchange, so it throws before any request goes out —

  [Auth] Failed to get auth token for ml: ML service requires a signed-in session

and it was wrong for signed-in visitors too. GET /reviews is owner-scoped, so the "public listing" showed the viewer their own reviews, and the detail route 404s for non-owners, so a published review was invisible to everyone but its author. The is_public toggle had no reader.

Point both pages at ml_service's new unauthenticated /synth-scholar/public/* routes (list, detail, log, export) via separate hooks and query keys, so a signed-in author's owner-scoped listing can't be served from cache in place of the published set.

Also close the session-outlives-credential gap behind the same error message:

  * Cap the NextAuth cookie at the backend's web refresh TTL (7 days) instead of NextAuth's 30-day default. The ~23-day difference was a window where the cookie reported `authenticated` while the credential behind it was gone.
  * Stop discarding credentials on a transient refresh failure. refreshBackendToken returned null for both "token rejected" and "could not reach the service", and the caller cleared the session either way — so a few-second backend hiccup permanently signed everyone out. Only 401/403 now count as a verdict.
  * Treat a login that carried no refresh token as expired once its access token lapses, rather than leaving a dead token for every caller to 401 on.
  * Surface session.error = "SessionExpired" and add SessionExpiryWatcher, mounted once in the layout, so an expired session becomes one sign-out and one notice instead of a different failure per feature.