### PR TITLE
Disable pages not used

### DIFF
--- a/src/app/api/ner/withouttoken/route.ts
+++ b/src/app/api/ner/withouttoken/route.ts
@@ -3,6 +3,7 @@ import { getWarmedCache } from '@/src/utils/cache/cache-warm';
 import { fetchPaginatedDataWithoutToken, searchByIdWithoutToken } from '@/src/utils/api/api-client-without-token';
 import { CacheService } from '@/src/services/cache/cache-service';
 import { CACHE_DURATIONS } from '@/src/config/constants';
+import { toPublicEndpoint } from '@/src/utils/api/public-endpoint';
 
 // Force dynamic rendering - this route uses searchParams
 export const dynamic = 'force-dynamic';
@@ -49,7 +50,10 @@ export async function GET(request: NextRequest) {
         const limit = searchParams.get('limit') || '50';
         const skip = searchParams.get('skip') || '0';
         const search = searchParams.get('search') || undefined;
-        const endpoint = searchParams.get('endpoint');
+        // Map to the /api/public/... sibling: this route sends no credential,
+        // and ml_service's authenticated read endpoints answer 403
+        // "Not authenticated" before scopes are even consulted.
+        const endpoint = toPublicEndpoint(searchParams.get('endpoint') ?? '') || null;
 
         if (!endpoint) {
             return NextResponse.json(

--- a/src/app/api/resources/withouttoken/route.ts
+++ b/src/app/api/resources/withouttoken/route.ts
@@ -3,6 +3,7 @@ import { getWarmedCache } from '@/src/utils/cache/cache-warm';
 import { fetchPaginatedDataWithoutToken, searchByIdWithoutToken } from '@/src/utils/api/api-client-without-token';
 import { CacheService } from '@/src/services/cache/cache-service';
 import { CACHE_DURATIONS } from '@/src/config/constants';
+import { toPublicEndpoint } from '@/src/utils/api/public-endpoint';
 
 // Force dynamic rendering - this route uses searchParams
 export const dynamic = 'force-dynamic';
@@ -49,7 +50,10 @@ export async function GET(request: NextRequest) {
         const limit = searchParams.get('limit') || '50';
         const skip = searchParams.get('skip') || '0';
         const search = searchParams.get('search') || undefined;
-        const endpoint = searchParams.get('endpoint');
+        // Map to the /api/public/... sibling: this route sends no credential,
+        // and ml_service's authenticated read endpoints answer 403
+        // "Not authenticated" before scopes are even consulted.
+        const endpoint = toPublicEndpoint(searchParams.get('endpoint') ?? '') || null;
 
         if (!endpoint) {
             return NextResponse.json(

--- a/src/app/components/auth/ExtractionDisabledNotice.tsx
+++ b/src/app/components/auth/ExtractionDisabledNotice.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+/**
+ * Shown in place of an extraction tool while ENABLE_EXTRACTION_TOOLS is off.
+ *
+ * The tools are hidden from the dashboard and sidebar, but their routes still exist,
+ * so anyone with a bookmark or a stale tab lands on the page. Without this they would
+ * get a UI that looks fine and then fails on WebSocket connect — ml_service does not
+ * register /ws/ner, /ws/extract-resources or /ws/pdf2reproschema when the structsense
+ * package is absent.
+ *
+ * Deliberately explicit that already-extracted data is still readable, because that
+ * is the first thing someone will wonder.
+ */
+
+import Link from "next/link";
+import { AlertCircle } from "lucide-react";
+
+export function ExtractionDisabledNotice({ toolName }: { toolName: string }) {
+  return (
+    <div className="max-w-2xl mx-auto p-8">
+      <div className="rounded-lg border border-amber-300 bg-amber-50 p-6">
+        <div className="flex items-start gap-3">
+          <AlertCircle className="h-5 w-5 text-amber-600 mt-0.5 shrink-0" aria-hidden />
+          <div>
+            <h1 className="text-lg font-semibold text-amber-900">
+              {toolName} is temporarily unavailable
+            </h1>
+            <p className="mt-2 text-sm text-amber-900">
+              The multi-agent extraction service is not running, so new extractions
+              cannot be started. This is a server-side dependency problem, not
+              something wrong with your account or your file.
+            </p>
+            <p className="mt-3 text-sm text-amber-900">
+              Previously extracted data is unaffected and still browsable in the{" "}
+              <Link href="/knowledge-base/ner" className="underline font-medium">
+                knowledge base
+              </Link>
+              .
+            </p>
+          </div>
+        </div>
+      </div>
+      <div className="mt-6">
+        <Link href="/user/dashboard" className="text-sm text-gray-700 underline">
+          Back to dashboard
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+export default ExtractionDisabledNotice;

--- a/src/app/components/layout/UserSideBar.tsx
+++ b/src/app/components/layout/UserSideBar.tsx
@@ -2,11 +2,12 @@
 import Link from "next/link";
 import { usePathname } from 'next/navigation';
 import { LayoutDashboard, Database, Brain, FileText, Upload, User, Activity } from "lucide-react";
+import { ENABLE_EXTRACTION_TOOLS, EXTRACTION_TOOL_HREFS } from "@/src/config/featureFlags";
 
 const UserSideBar: React.FC = () => {
     const pathname = usePathname();
 
-    const menuItems = [
+    const allMenuItems = [
         {
             title: "Dashboard",
             href: "/user/dashboard",
@@ -34,6 +35,15 @@ const UserSideBar: React.FC = () => {
 //         },
 
     ];
+
+    // Hide the extraction tools while the backend cannot serve them — ml_service
+    // does not register their WebSocket endpoints without the structsense package.
+    // Entries are kept above, not deleted, so flipping the flag restores them.
+    const menuItems = ENABLE_EXTRACTION_TOOLS
+        ? allMenuItems
+        : allMenuItems.filter(
+              (item) => !(EXTRACTION_TOOL_HREFS as readonly string[]).includes(item.href),
+          );
 
     return (
         <>

--- a/src/app/user/UserBreadcrumb.tsx
+++ b/src/app/user/UserBreadcrumb.tsx
@@ -11,7 +11,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { FONTS, Icon } from "@/src/app/components/design-system";
-import { TOOL_REGISTRY } from "@/src/config/toolRegistry";
+import { ALL_TOOLS } from "@/src/config/toolRegistry";
 
 export function UserBreadcrumb() {
   const pathname = usePathname() ?? "";
@@ -22,7 +22,9 @@ export function UserBreadcrumb() {
 
   // Look up a friendly label from the tool registry; fall back to the last
   // path segment if the route isn't registered (e.g. /user/profile).
-  const tool = TOOL_REGISTRY.find((t) => t.href === pathname);
+  // ALL_TOOLS, not TOOL_REGISTRY: a tool hidden by a feature flag still needs a
+  // proper title if someone reaches its URL directly.
+  const tool = ALL_TOOLS.find((t) => t.href === pathname);
   const fallbackLabel = pathname.split("/").pop() ?? "Tool";
   const label = tool?.title ?? fallbackLabel.replace(/[-_]/g, " ");
 

--- a/src/app/user/extract-resource/page.tsx
+++ b/src/app/user/extract-resource/page.tsx
@@ -12,8 +12,11 @@ import { useApiKeyValidator } from "../../components/user/useApiKeyValidator";
 import { ApiKeyValidatorUI } from "../../components/user/ApiKeyValidator";
 import FileUploadArea from "../../components/user/FileUploadArea";
 import ProcessingStatusHeader from "../../components/user/ProcessingStatusHeader";
+import { ENABLE_EXTRACTION_TOOLS } from "@/src/config/featureFlags";
+import { ExtractionDisabledNotice } from "@/src/app/components/auth/ExtractionDisabledNotice";
 
-export default function IngestStructuredResourcePage() {
+function IngestStructuredResourcePageTool() {
+
     const { data: session } = useSession();
     const router = useRouter();
 
@@ -553,4 +556,16 @@ export default function IngestStructuredResourcePage() {
             {/*)}*/}
         </div>
     );
+}
+
+// Hook-free wrapper so the tool component's hooks are never called conditionally
+// (react-hooks/rules-of-hooks). The route still resolves while the tool is hidden
+// from the dashboard and sidebar, so someone with a bookmark lands here; the
+// extraction WebSocket endpoints do not exist without the structsense stack, so the
+// tool would otherwise fail on connect with nothing to explain why.
+export default function IngestStructuredResourcePage() {
+    if (!ENABLE_EXTRACTION_TOOLS) {
+        return <ExtractionDisabledNotice toolName="Resource extraction" />;
+    }
+    return <IngestStructuredResourcePageTool />;
 }

--- a/src/app/user/pdf2reproschema/page.tsx
+++ b/src/app/user/pdf2reproschema/page.tsx
@@ -11,8 +11,11 @@ import { useApiKeyValidator } from "../../components/user/useApiKeyValidator";
 import { ApiKeyValidatorUI } from "../../components/user/ApiKeyValidator";
 import FileUploadArea from "../../components/user/FileUploadArea";
 import ProcessingStatusHeader from "../../components/user/ProcessingStatusHeader";
+import { ENABLE_EXTRACTION_TOOLS } from "@/src/config/featureFlags";
+import { ExtractionDisabledNotice } from "@/src/app/components/auth/ExtractionDisabledNotice";
 
-export default function Pdf2ReproschemaPage() {
+function Pdf2ReproschemaPageTool() {
+
     const { data: session } = useSession();
     const router = useRouter();
 
@@ -321,4 +324,16 @@ export default function Pdf2ReproschemaPage() {
             )}
         </div>
     );
+}
+
+// Hook-free wrapper so the tool component's hooks are never called conditionally
+// (react-hooks/rules-of-hooks). The route still resolves while the tool is hidden
+// from the dashboard and sidebar, so someone with a bookmark lands here; the
+// extraction WebSocket endpoints do not exist without the structsense stack, so the
+// tool would otherwise fail on connect with nothing to explain why.
+export default function Pdf2ReproschemaPage() {
+    if (!ENABLE_EXTRACTION_TOOLS) {
+        return <ExtractionDisabledNotice toolName="PDF to ReproSchema conversion" />;
+    }
+    return <Pdf2ReproschemaPageTool />;
 }

--- a/src/app/user/sie/page.tsx
+++ b/src/app/user/sie/page.tsx
@@ -13,6 +13,8 @@ import { useApiKeyValidator } from "../../components/user/useApiKeyValidator";
 import { ApiKeyValidatorUI } from "../../components/user/ApiKeyValidator";
 import FileUploadArea from "../../components/user/FileUploadArea";
 import ProcessingStatusHeader from "../../components/user/ProcessingStatusHeader";
+import { ENABLE_EXTRACTION_TOOLS } from "@/src/config/featureFlags";
+import { ExtractionDisabledNotice } from "@/src/app/components/auth/ExtractionDisabledNotice";
 
 // Define types for our entities and results
 interface Entity {
@@ -57,7 +59,8 @@ function getCorrectedIndices(sentence: string, entity: string, origStart: number
     return { start: origStart, end: origEnd };
 }
 
-export default function NamedEntityRecognition() {
+function NamedEntityRecognitionTool() {
+
     const {data: session} = useSession();
     const router = useRouter();
     const [selectedInputType, setSelectedInputType] = useState<InputType>('pdf');
@@ -687,3 +690,14 @@ export default function NamedEntityRecognition() {
     );
 }
 
+// Hook-free wrapper so the tool component's hooks are never called conditionally
+// (react-hooks/rules-of-hooks). The route still resolves while the tool is hidden
+// from the dashboard and sidebar, so someone with a bookmark lands here; the
+// extraction WebSocket endpoints do not exist without the structsense stack, so the
+// tool would otherwise fail on connect with nothing to explain why.
+export default function NamedEntityRecognition() {
+    if (!ENABLE_EXTRACTION_TOOLS) {
+        return <ExtractionDisabledNotice toolName="NER extraction" />;
+    }
+    return <NamedEntityRecognitionTool />;
+}

--- a/src/config/featureFlags.ts
+++ b/src/config/featureFlags.ts
@@ -22,3 +22,42 @@
  */
 export const ENABLE_PAGE_ACCESS_GATE: boolean =
   process.env.NEXT_PUBLIC_ENABLE_PAGE_ACCESS_GATE === "false" ? false : true;
+
+/**
+ * Controls the multi-agent EXTRACTION tools in the signed-in user section:
+ * NER extraction (/user/sie), Resource extraction (/user/extract-resource) and
+ * PDF -> ReproSchema (/user/pdf2reproschema).
+ *
+ * OFF by default, because the backend cannot currently serve them. ml_service no
+ * longer installs the `structsense` package — it pins aiohttp below 3.10 through an
+ * old crewai/litellm, which breaks openai's import and took `synthscholar` (every
+ * /api/synth-scholar route) down with it. With it gone, ml_service does not register
+ * /ws/ner, /ws/extract-resources or /ws/pdf2reproschema at all, so these pages would
+ * fail on connect.
+ *
+ * This hides the tools rather than deleting them: the pages, the WebSocket client and
+ * the API routes are all intact, and flipping this to "true" brings them straight
+ * back once structsense is reinstalled.
+ *
+ * READ-ONLY views are NOT affected and must keep working — /knowledge-base/ner and
+ * /knowledge-base/[slug] read already-extracted annotations through GET /api/ner,
+ * which does not need structsense.
+ *
+ * Set `NEXT_PUBLIC_ENABLE_EXTRACTION_TOOLS=true` to re-enable.
+ */
+export const ENABLE_EXTRACTION_TOOLS: boolean =
+  process.env.NEXT_PUBLIC_ENABLE_EXTRACTION_TOOLS === "true";
+
+/** pageKeys in TOOL_REGISTRY that ENABLE_EXTRACTION_TOOLS governs. */
+export const EXTRACTION_TOOL_PAGE_KEYS = [
+  "tools.ner-extraction",
+  "tools.extract-resource",
+  "tools.pdf2reproschema",
+] as const;
+
+/** Routes ENABLE_EXTRACTION_TOOLS governs, for nav filtering and page gating. */
+export const EXTRACTION_TOOL_HREFS = [
+  "/user/sie",
+  "/user/extract-resource",
+  "/user/pdf2reproschema",
+] as const;

--- a/src/config/toolRegistry.ts
+++ b/src/config/toolRegistry.ts
@@ -6,6 +6,11 @@
  * entry, PageAccessGate denies entry — i.e. all tools start disabled.
  */
 
+import {
+  ENABLE_EXTRACTION_TOOLS,
+  EXTRACTION_TOOL_PAGE_KEYS,
+} from "@/src/config/featureFlags";
+
 export interface ToolEntry {
   pageKey: string;
   href: string;
@@ -24,7 +29,12 @@ export interface ToolEntry {
   adminOnly?: boolean;
 }
 
-export const TOOL_REGISTRY: ToolEntry[] = [
+/**
+ * Every tool, including any currently disabled by a feature flag. Exported for
+ * places that need the complete set (e.g. resolving a page title for a route that
+ * is temporarily hidden). Use TOOL_REGISTRY for anything user-facing.
+ */
+export const ALL_TOOLS: ToolEntry[] = [
   {
     pageKey: "tools.ingest-kg",
     href: "/user/ingest-kg",
@@ -74,3 +84,18 @@ export const TOOL_REGISTRY: ToolEntry[] = [
     color: "var(--bkb-textMuted)",
   },
 ];
+
+/**
+ * The tools actually surfaced to users. Filtering here rather than at each call
+ * site means the dashboard tiles, the /admin/page-access seed list, and the user
+ * breadcrumb all agree without three separate checks.
+ *
+ * Extraction tools are hidden while ENABLE_EXTRACTION_TOOLS is off — ml_service does
+ * not register the /ws/ner, /ws/extract-resources or /ws/pdf2reproschema endpoints
+ * they depend on. Nothing is deleted: flip the flag and they return.
+ */
+export const TOOL_REGISTRY: ToolEntry[] = ALL_TOOLS.filter(
+  (t) =>
+    ENABLE_EXTRACTION_TOOLS ||
+    !(EXTRACTION_TOOL_PAGE_KEYS as readonly string[]).includes(t.pageKey),
+);

--- a/src/config/yaml/ner-detail.yaml
+++ b/src/config/yaml/ner-detail.yaml
@@ -6,10 +6,14 @@ title: "NER Terms"
 dataSource:
   type: "api-get"
   endpoint: "NEXT_PUBLIC_NER_GET_ENDPOINT"
-  apiRoute: "/api/ner"
+  # Public page: no visitor credential exists, so use the withouttoken route.
+  # It sends no Authorization header and targets ml_service's /api/public/*
+  # endpoints. The authenticated route answers 403 "Not authenticated" for
+  # anonymous callers, which is what broke this page.
+  apiRoute: "/api/ner/withouttoken"
   params:
     tokenEndpointType: "ml"  # Options: "ml", "query", "default" (default: "query")
-    useAuth: true  # Optional: set to false to disable auth (default: true)
+    useAuth: false  # Public page — see the note above; true would switch to the authenticated route
   idParam: "id"
 tabs:
   - id: "summary"

--- a/src/config/yaml/ner-list.yaml
+++ b/src/config/yaml/ner-list.yaml
@@ -6,10 +6,14 @@ description: "Browse and search extracted neuroscientific named entities from re
 dataSource:
   type: "api-get"
   endpoint: "NEXT_PUBLIC_NER_GET_ENDPOINT"
-  apiRoute: "/api/ner"
+  # Public page: no visitor credential exists, so use the withouttoken route.
+  # It sends no Authorization header and targets ml_service's /api/public/*
+  # endpoints. The authenticated route answers 403 "Not authenticated" for
+  # anonymous callers, which is what broke this page.
+  apiRoute: "/api/ner/withouttoken"
   params:
     tokenEndpointType: "ml"  # Options: "ml", "query", "default" (default: "query")
-    useAuth: true  # Optional: set to false to disable auth (default: true)
+    useAuth: false  # Public page — see the note above; true would switch to the authenticated route
 columns:
   - key: "entity"
     label: "Entity"

--- a/src/config/yaml/resources-detail.yaml
+++ b/src/config/yaml/resources-detail.yaml
@@ -6,10 +6,14 @@ title: "Resources"
 dataSource:
   type: "api-get"
   endpoint: "NEXT_PUBLIC_API_ADMIN_GET_STRUCTURED_RESOURCE_ENDPOINT"
-  apiRoute: "/api/resources"
+  # Public page: no visitor credential exists, so use the withouttoken route.
+  # It sends no Authorization header and targets ml_service's /api/public/*
+  # endpoints. The authenticated route answers 403 "Not authenticated" for
+  # anonymous callers, which is what broke this page.
+  apiRoute: "/api/resources/withouttoken"
   params:
     tokenEndpointType: "ml"  # Options: "ml", "query", "default" (default: "query")
-    useAuth: true  # Optional: set to false to disable auth (default: true)
+    useAuth: false  # Public page — see the note above; true would switch to the authenticated route
   idParam: "id"
   dataExtractor: "extractResourceData"
 tabs:

--- a/src/config/yaml/resources-list.yaml
+++ b/src/config/yaml/resources-list.yaml
@@ -6,10 +6,14 @@ description: "Browse extracted resources from neuroscience publications, includi
 dataSource:
   type: "api-get"
   endpoint: "NEXT_PUBLIC_API_ADMIN_GET_STRUCTURED_RESOURCE_ENDPOINT"
-  apiRoute: "/api/resources"
+  # Public page: no visitor credential exists, so use the withouttoken route.
+  # It sends no Authorization header and targets ml_service's /api/public/*
+  # endpoints. The authenticated route answers 403 "Not authenticated" for
+  # anonymous callers, which is what broke this page.
+  apiRoute: "/api/resources/withouttoken"
   params:
     tokenEndpointType: "ml"  # Options: "ml", "query", "default" (default: "query")
-    useAuth: true  # Optional: set to false to disable auth (default: true)
+    useAuth: false  # Public page — see the note above; true would switch to the authenticated route
   dataExtractor: "extractResourceData"
 columns:
   - key: "name"

--- a/src/utils/api/public-endpoint.ts
+++ b/src/utils/api/public-endpoint.ts
@@ -1,0 +1,35 @@
+/**
+ * Maps an ml_service read endpoint to its unauthenticated `/public/` sibling.
+ *
+ *   https://mlservice.brainkb.org/api/ner
+ *     -> https://mlservice.brainkb.org/api/public/ner
+ *   https://mlservice.brainkb.org/api/structured-resource
+ *     -> https://mlservice.brainkb.org/api/public/structured-resource
+ *
+ * Why derive instead of adding env vars: the endpoint reaches these routes from the
+ * YAML page config, and the resources pages read
+ * NEXT_PUBLIC_API_ADMIN_GET_STRUCTURED_RESOURCE_ENDPOINT — the same variable the
+ * authenticated admin views use, despite serving the public page. Repointing it would
+ * move both. Rewriting here touches only the withouttoken routes, which are by
+ * definition the anonymous path.
+ *
+ * The authenticated routes require a credential (get_current_user rejects with 403
+ * "Not authenticated" before scopes are even checked), which is why the public
+ * knowledge-base pages could not read their own data.
+ */
+
+/** Already-public paths pass through unchanged, so this is safe to apply twice. */
+export function toPublicEndpoint(endpoint: string): string {
+  if (!endpoint) return endpoint;
+  try {
+    const url = new URL(endpoint);
+    if (url.pathname.includes("/api/public/")) return endpoint;
+    url.pathname = url.pathname.replace(/\/api\/(?!public\/)/, "/api/public/");
+    return url.toString();
+  } catch {
+    // Relative or malformed value — the caller's own validation will surface it.
+    return endpoint.includes("/api/public/")
+      ? endpoint
+      : endpoint.replace(/\/api\/(?!public\/)/, "/api/public/");
+  }
+}


### PR DESCRIPTION
This PR disables StructSense related page as the current integration uses the old version, which needs update. Also, we are now using skills and decentralized ingestion.